### PR TITLE
Detect steam and r6s path instead of hardcode

### DIFF
--- a/NET/AppLocker/App.xaml.cs
+++ b/NET/AppLocker/App.xaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.IO;
+using Microsoft.Win32;
 
 namespace AppLocker
 {
@@ -14,8 +15,8 @@ namespace AppLocker
     /// </summary>
     public partial class App : Application
     {
-        private const string steamPath = @"C:\Program Files (x86)\Steam\steam.exe",
-                             steamSavePath = @"C:\Program Files (x86)\Steam\DataChunk",
+        private static string steamPath = @"C:\Program Files\Steam\steam.exe",
+                             steamSavePath = @"C:\Program Files\Steam\DataChunk",
                              r6Path1 = @"C:\Program Files (x86)\Steam\steamapps\common\Tom Clancy's Rainbow Six Siege\RainbowSix.exe",
                              r6Path2 = @"C:\Program Files (x86)\Steam\steamapps\common\Tom Clancy's Rainbow Six Siege\RainbowSix_Vulkan.exe",
                              r6SavePath1 = @"C:\Program Files (x86)\Steam\steamapps\common\Tom Clancy's Rainbow Six Siege\DataChunk1",
@@ -60,8 +61,41 @@ namespace AppLocker
             {
                 App.steamExists = File.Exists(steamPath) ? EXIST : NOT_EXIST;
             }
+
+            if (App.steamExists == App.NOT_EXIST)  // fall back to find steam from registry.
+            {
+                FindSteam();
+                App.steamExists = File.Exists(steamPath) ? EXIST : NOT_EXIST;  // Check again
+            }
             return steamExists == App.EXIST;
         }
+
+        public static void FindSteam()
+        {
+            try
+            {
+                RegistryKey key1 = Registry.CurrentUser.OpenSubKey("Software\\Valve\\Steam");
+
+                if (key1 != null)
+                {
+                    String exePath = key1.GetValue("SteamExe").ToString();
+                    String dirPath = key1.GetValue("SteamPath").ToString();
+                    steamPath = exePath;
+                    steamSavePath = dirPath + "/DataChunk";
+                }
+                
+            }
+            catch (Exception ex)
+            {
+                // Just do nothing ,,, for now
+            }
+        }
+
+        public static String GetSteamPath()
+        {
+            return steamPath;
+        }
+        
         public static bool CheckR6Exist()
         {
             if (App.r6Exists == 0)

--- a/NET/AppLocker/MainWindow.xaml.cs
+++ b/NET/AppLocker/MainWindow.xaml.cs
@@ -24,13 +24,13 @@ namespace AppLocker
         {
             InitializeComponent();
             if (App.CheckSteamExist())
-                steamStatus.Text = "Steam exists at \"" + App.GetSteamPath() + "\"";
+                steamStatus.Text = "Steam found in \"" + App.GetSteamPath() + "\"";
             else
                 steamStatus.Text = "Steam locked!";
             if (App.CheckR6Exist())
-                r6Status.Text = "R6 exists!";
+                r6Status.Text = "R6S found in \""+ App.GetR6Path() + "\"";
             else
-                r6Status.Text = "R6 locked!";
+                r6Status.Text = "R6S locked!";
         }
 
         private void steamLockButton_Click(object sender, RoutedEventArgs e)

--- a/NET/AppLocker/MainWindow.xaml.cs
+++ b/NET/AppLocker/MainWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace AppLocker
         {
             InitializeComponent();
             if (App.CheckSteamExist())
-                steamStatus.Text = "Steam exists!";
+                steamStatus.Text = "Steam exists at \"" + App.GetSteamPath() + "\"";
             else
                 steamStatus.Text = "Steam locked!";
             if (App.CheckR6Exist())


### PR DESCRIPTION
Instead of hardcoding all the paths, I made it that now, 
the program can detect steam path from Windows registry and find r6s path from steam libraries.